### PR TITLE
JIT: implement return merging stress mode

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -9137,6 +9137,7 @@ public:
         STRESS_MODE(CLONE_EXPR)                                                                 \
         STRESS_MODE(USE_CMOV)                                                                   \
         STRESS_MODE(FOLD)                                                                       \
+        STRESS_MODE(MERGED_RETURNS)                                                             \
         STRESS_MODE(BB_PROFILE)                                                                 \
         STRESS_MODE(OPT_BOOLS_GC)                                                               \
         STRESS_MODE(REMORPH_TREES)                                                              \

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -9311,14 +9311,16 @@ void Compiler::fgAddInternal()
     }
     else
     {
+        bool stressMerging = compStressCompile(STRESS_MERGED_RETURNS, 50);
+
         //
         // We are allowed to have multiple individual exits
         // However we can still decide to have a single return
         //
-        if (compCodeOpt() == SMALL_CODE)
+        if ((compCodeOpt() == SMALL_CODE) || stressMerging)
         {
-            // For the Small_Code case we always generate a
-            // single return block when we have multiple
+            // Under stress or for Small_Code case we always
+            // generate a single return block when we have multiple
             // return points
             //
             merger.SetMaxReturns(1);


### PR DESCRIPTION
Under stress, optionally limit methods to having just one return block,
to stress the logic involved in merging returns.